### PR TITLE
Share an antibot hash set across index pages

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1202,6 +1202,7 @@ function buildIndex() {
 	global $board, $config;
 	
 	$pages = getPages();
+	$antibot = create_antibot($board['uri']);
 
 	$page = 1;
 	while ($page <= $config['max_pages'] && $content = index($page)) {
@@ -1211,7 +1212,7 @@ function buildIndex() {
 		$content['pages'] = $pages;
 		$content['pages'][$page-1]['selected'] = true;
 		$content['btn'] = getPageButtons($content['pages']);
-		$content['antibot'] = create_antibot($board['uri']);
+		$content['antibot'] = $antibot;
 		file_write($filename, Element('index.html', $content));
 		
 		if (isset($md5) && $md5 == md5_file($filename)) {


### PR DESCRIPTION
This addresses an issue on slow boards where all except the last page of an index would have their hashes expire due to too many calls to create_antibot().
