### PR TITLE
Heading format fix

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -362,7 +362,7 @@
 	$config['markup'][] = array("/'''(.+?)'''/", "<strong>\$1</strong>");
 	$config['markup'][] = array("/''(.+?)''/", "<em>\$1</em>");
 	$config['markup'][] = array("/\*\*(.+?)\*\*/", "<span class=\"spoiler\">\$1</span>");
-	$config['markup'][] = array("/^\s*==(.+?)==\s*$/m", "<span class=\"heading\">\$1</span>");
+	$config['markup'][] = array("/^[ |\t]*==(.+?)==[ |\t]*$/m", "<span class=\"heading\">\$1</span>");
 	
 	// Highlight PHP code wrapped in <code> tags (PHP 5.3.0+)
 	// $config['markup'][] = array(

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -268,6 +268,7 @@ span.heading {
 span.spoiler {
 	background: black;
 	color: black;
+	padding: 0px 1px;
 }
 div.post.reply p.body span.spoiler a {
 	color: black;

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -263,7 +263,6 @@ span.heading {
 	color: #AF0A0F;
 	font-size: 11pt;
 	font-weight: bold;
-	display: block;
 }
 span.spoiler {
 	background: black;


### PR DESCRIPTION
Fixes issues with heading displaying weirdly, including eating linebreaks above it and forcing a single linebreak below.
