### PR TITLE
Adds "View Last 50 Posts" pages

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -458,6 +458,10 @@
 	// WARNING: Currently strips animated GIFs too
 	$config['redraw_image'] = false;
 	
+	// Number of posts in a "View Last X Posts" page
+	$config['noko50_count'] = 50;
+	// Number of posts a thread needs before it gets a "View Last X Posts" page
+	$config['noko50_min'] = 100;
 /*
  * ====================
  *  Board settings
@@ -707,6 +711,7 @@
 	
 	$config['file_index'] = 'index.html';
 	$config['file_page'] = '%d.html';
+	$config['file_page50'] = '%d+50.html';
 	$config['file_mod'] = 'mod.php';
 	$config['file_post'] = 'post.php';
 	$config['file_script'] = 'main.js';

--- a/inc/display.php
+++ b/inc/display.php
@@ -354,6 +354,9 @@ class Thread {
 	public function add(Post $post) {
 		$this->posts[] = $post;
 	}
+	public function postCount() {
+	       return count($this->posts) + $this->omitted;
+	}
 	public function postControls() {
 		global $board, $config;
 		
@@ -421,10 +424,12 @@ class Thread {
 		return fraction($this->filex, $this->filey, ':');
 	}
 	
-	public function build($index=false) {
+	public function build($index=false, $isnoko50=false) {
 		global $board, $config, $debug;
 		
-		$built = Element('post_thread.html', Array('config' => $config, 'board' => $board, 'post' => &$this, 'index' => $index));
+		$hasnoko50 = $this->postCount() >= $config['noko50_min'];
+
+		$built = Element('post_thread.html', Array('config' => $config, 'board' => $board, 'post' => &$this, 'index' => $index, 'hasnoko50' => $hasnoko50, 'isnoko50' => $isnoko50));
 		
 		if (!$this->mod && $index && $config['cache']['enabled']) {
 			cache::set($this->cache_key($index), $built);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -83,7 +83,10 @@ function loadConfig() {
 					'|' .
 						str_replace('%s', '\w+', preg_quote($config['board_path'], '/')) .
 						preg_quote($config['dir']['res'], '/') .
-						str_replace('%d', '\d+', preg_quote($config['file_page'], '/')) .
+						'(' .
+							str_replace('%d', '\d+', preg_quote($config['file_page'], '/')) . '|' .
+							str_replace('%d', '\d+', preg_quote($config['file_page50'], '/')) .
+						')' .
 					'|' .
 						preg_quote($config['file_mod'], '/') . '\?\/.+' .
 				')([#?](.+)?)?$/i';
@@ -858,6 +861,7 @@ function deletePost($id, $error_if_doesnt_exist=true, $rebuild_after=true) {
 		if (!$post['thread']) {
 			// Delete thread HTML page
 			file_unlink($board['dir'] . $config['dir']['res'] . sprintf($config['file_page'], $post['id']));
+			file_unlink($board['dir'] . $config['dir']['res'] . sprintf($config['file_page50'], $post['id']));
 			
 			$antispam_query = prepare('DELETE FROM `antispam` WHERE `board` = :board AND `thread` = :thread');
 			$antispam_query->bindValue(':board', $board['uri']);
@@ -1500,21 +1504,117 @@ function buildThread($id, $return=false, $mod=false) {
 	if (!isset($thread))
 		error($config['error']['nonexistant']);
 	
+	$hasnoko50 = $thread->postCount() >= $config['noko50_min'];
+
 	$body = Element('thread.html', array(
 		'board'=>$board, 
 		'body'=>$thread->build(),
 		'config' => $config,
 		'id' => $id,
 		'mod' => $mod,
+		'hasnoko50' => $hasnoko50,
+		'isnoko50' => false,
 		'antibot' => $mod ? false : create_antibot($board['uri'], $id),
 		'boardlist' => createBoardlist($mod),
 		'return' => ($mod ? '?' . $board['url'] . $config['file_index'] : $config['root'] . $board['uri'] . '/' . $config['file_index'])
 	));
 	
-	if ($return)
+	if ($return) {
 		return $body;
-	else
+	} else {
+		$noko50fn = $board['dir'] . $config['dir']['res'] . sprintf($config['file_page50'], $id);
+		if ($hasnoko50 || file_exists($noko50fn)) {
+			buildThread50($id, $return, $mod, $thread);
+		}
+
 		file_write($board['dir'] . $config['dir']['res'] . sprintf($config['file_page'], $id), $body);
+	}
+}
+
+function buildThread50($id, $return=false, $mod=false, $thread=null) {
+	global $board, $config;
+	$id = round($id);
+	
+	if (event('build-thread', $id))
+		return;
+
+	if (!$thread) {
+		$query = prepare(sprintf("SELECT * FROM `posts_%s` WHERE (`thread` IS NULL AND `id` = :id) OR `thread` = :id ORDER BY `thread`,`id` DESC LIMIT :limit", $board['uri']));
+		$query->bindValue(':id', $id, PDO::PARAM_INT);
+		$query->bindValue(':limit', $config['noko50_count']+1, PDO::PARAM_INT);
+		$query->execute() or error(db_error($query));
+		
+		$num_images = 0;
+		while ($post = $query->fetch()) {
+			if (!isset($thread)) {
+				$thread = new Thread(
+					$post['id'], $post['subject'], $post['email'], $post['name'], $post['trip'], $post['capcode'], $post['body'], $post['time'],
+					$post['thumb'], $post['thumbwidth'], $post['thumbheight'], $post['file'], $post['filewidth'], $post['fileheight'], $post['filesize'],
+					$post['filename'], $post['ip'], $post['sticky'], $post['locked'], $post['sage'], $post['embed'], $mod ? '?/' : $config['root'], $mod
+				);
+			} else {
+				if ($post['file'])
+					$num_images++;
+				
+				$thread->add(new Post(
+					$post['id'], $thread->id, $post['subject'], $post['email'], $post['name'], $post['trip'], $post['capcode'], $post['body'],
+					$post['time'], $post['thumb'], $post['thumbwidth'], $post['thumbheight'], $post['file'], $post['filewidth'], $post['fileheight'],
+					$post['filesize'], $post['filename'], $post['ip'], $post['embed'], $mod ? '?/' : $config['root'], $mod)
+				);
+			}
+		}
+
+		// Check if any posts were found
+		if (!isset($thread))
+			error($config['error']['nonexistant']);
+
+
+		if ($query->rowCount() == $config['noko50_count']+1) {
+			$count = prepare(sprintf("SELECT COUNT(`id`) as `num` FROM `posts_%s` WHERE `thread` = :thread UNION ALL SELECT COUNT(`id`) FROM `posts_%s` WHERE `file` IS NOT NULL AND `thread` = :thread", $board['uri'], $board['uri']));
+			$count->bindValue(':thread', $id, PDO::PARAM_INT);
+			$count->execute() or error(db_error($count));
+			
+			$c = $count->fetch();
+			$thread->omitted = $c['num'] - $config['noko50_count'];
+			
+			$c = $count->fetch();
+			$thread->omitted_images = $c['num'] - $num_images;
+		}
+
+		$thread->posts = array_reverse($thread->posts);
+	} else {
+		$allPosts = $thread->posts;
+
+		$thread->posts = array_slice($allPosts, -$config['noko50_count']);
+		$thread->omitted += count($allPosts) - count($thread->posts);
+		foreach ($allPosts as $index => $post) {
+			if ($index == count($allPosts)-count($thread->posts))
+				break;  
+			if ($post->file)
+				$thread->omitted_images++;
+		}
+	}
+		
+	$hasnoko50 = $thread->postCount() >= $config['noko50_min'];
+
+	$body = Element('thread.html', array(
+		'board'=>$board, 
+		'body'=>$thread->build(false, true),
+		'config' => $config,
+		'id' => $id,
+		'mod' => $mod,
+		'hasnoko50' => $hasnoko50,
+		'isnoko50' => true,
+		'antibot' => $mod ? false : create_antibot($board['uri'], $id),
+		'boardlist' => createBoardlist($mod),
+		'return' => ($mod ? '?' . $board['url'] . $config['file_index'] : $config['root'] . $board['uri'] . '/' . $config['file_index'])
+	));
+	
+	if ($return) {
+		return $body;
+	} else {
+		file_write($board['dir'] . $config['dir']['res'] . sprintf($config['file_page50'], $id), $body);
+	}
 }
 
  function rrmdir($dir) {

--- a/mod.php
+++ b/mod.php
@@ -63,6 +63,7 @@ if(!$mod) {
 	$regex = array(
 		'board' => str_replace('%s', '(\w{1,8})', preg_quote($config['board_path'], '/')),
 		'page' => str_replace('%d', '(\d+)', preg_quote($config['file_page'], '/')),
+		'page50' => str_replace('%d', '(\d+)', preg_quote($config['file_page50'], '/')),
 		'img' => preg_quote($config['dir']['img'], '/'),
 		'thumb' => preg_quote($config['dir']['thumb'], '/'),
 		'res' => preg_quote($config['dir']['res'], '/'),
@@ -2219,6 +2220,18 @@ if(!$mod) {
 			error($config['error']['noboard']);
 		
 		$page = buildThread($thread, true, $mod);
+		
+		echo $page;
+	} elseif(preg_match('/^\/' . $regex['board'] . $regex['res'] . $regex['page50'] . '$/', $query, $matches)) {
+		// View last 50 posts in thread
+		
+		$boardName = &$matches[1];
+		$thread = &$matches[2];
+		// Open board
+		if(!openBoard($boardName))
+			error($config['error']['noboard']);
+		
+		$page = buildThread50($thread, true, $mod);
 		
 		echo $page;
 	} elseif(preg_match('/^\/' . $regex['board'] . 'edit\/(\d+)$/', $query, $matches)) {

--- a/post.php
+++ b/post.php
@@ -574,6 +574,20 @@ if (isset($_POST['delete'])) {
 	if ($config['always_noko'] || $noko) {
 		$redirect = $root . $board['dir'] . $config['dir']['res'] .
 			sprintf($config['file_page'], $post['op'] ? $id:$post['thread']) . (!$post['op'] ? '#' . $id : '');
+
+	   	if (!$post['op'] && isset($_SERVER['HTTP_REFERER'])) {
+			$regex = array(
+				'board' => str_replace('%s', '(\w{1,8})', preg_quote($config['board_path'], '/')),
+				'page' => str_replace('%d', '(\d+)', preg_quote($config['file_page'], '/')),
+				'page50' => str_replace('%d', '(\d+)', preg_quote($config['file_page50'], '/')),
+				'res' => preg_quote($config['dir']['res'], '/'),
+			);
+
+			if (preg_match('/\/' . $regex['board'] . $regex['res'] . $regex['page50'] . '([?&].*)?$/', $_SERVER['HTTP_REFERER'])) {
+				$redirect = $root . $board['dir'] . $config['dir']['res'] .
+					sprintf($config['file_page50'], $post['op'] ? $id:$post['thread']) . (!$post['op'] ? '#' . $id : '');
+			}
+		}
 	} else {
 		$redirect = $root . $board['dir'] . $config['file_index'];
 		

--- a/templates/post_thread.html
+++ b/templates/post_thread.html
@@ -98,7 +98,14 @@
 		<img class="icon" title="Bumplocked" src="{{ config.image_bumplocked }}" alt="Bumplocked" />
 	{% endif %}
 	{% if index %}
-		<a href="{{ post.root }}{{ board.dir }}{{ config.dir.res }}{{ config.file_page|sprintf(post.id) }}">[{% trans %}Reply{% endtrans %}]</a>
+		<a href="{{ post.root }}{{ board.dir }}{{ config.dir.res }}{{ config.file_page|sprintf(post.id) }}">[{% trans %}View{% endtrans %}]</a>
+	{% endif %}
+	{% if isnoko50 %}
+		<a href="{{ post.root }}{{ board.dir }}{{ config.dir.res }}{{ config.file_page|sprintf(post.id) }}">[{% trans %}View All{% endtrans %}]</a>
+	{% endif %}
+	{% if hasnoko50 and not isnoko50 %}
+		{% set lastcount = config.noko50_count %}
+		<a href="{{ post.root }}{{ board.dir }}{{ config.dir.res }}{{ config.file_page50|sprintf(post.id) }}">[{% trans %}Last {{ lastcount }} Posts{% endtrans %}]</a>
 	{% endif %}
 	{{ post.postControls }}
 	</p>
@@ -123,7 +130,7 @@
 				{% plural post.omitted_images %}
 					{{ count }} image replies
 				{% endtrans %}
-			{% endif %} {% trans %}omitted. Click reply to view.{% endtrans %}
+			{% endif %} {% trans %}omitted. Click View to see all.{% endtrans %}
 		</span>
 	{% endif %}
 {% if not index %}


### PR DESCRIPTION
This makes it so by default, if a thread goes over 100 posts (configurable), a separate page to view the last 50 posts (configurable) is added. I've called this feature in the code and config "noko50" after the feature of some other boards, though "noko50" isn't actually something interpreted in the email field, and the number of posts on the "View Last X Posts" page is configurable.

Every time a post is made to a thread, it's checked whether the thread has over 100 posts or if the noko50 page already exists ("%d+50.html" by default), and if so, it's updated. (This is so if a lot of posts are deleted from a thread bringing it back down below 100 posts, the noko50 page doesn't need to be deleted, and anyone on the noko50 page with a page auto-updating script isn't left in the dust.)

When building the noko50 page, the $thread object used to build the full thread page is re-used. For cases where the noko50 page needs to be generated without the full thread page (like from the mod interface), SQL is done similarly to how thread index previews are made that only gets the most recent 50 posts. The SQL in both of those places probably ought to be consolidated into a single function somewhere due to the similarities.
