### PR TITLE
Antibot make_confusing fix

### DIFF
--- a/inc/anti-bot.php
+++ b/inc/anti-bot.php
@@ -48,8 +48,9 @@ class AntiBot {
 		
 		foreach ($chars as &$c) {
 			if (rand(0, 2) != 0)
-				continue;
-			$c = mb_encode_numericentity($c, array(0, 0xffff, 0, 0xffff), 'UTF-8');
+				$c = utf8tohtml($c);
+			else
+				$c = mb_encode_numericentity($c, array(0, 0xffff, 0, 0xffff), 'UTF-8');
 		}
 		
 		return implode('', $chars);


### PR DESCRIPTION
The make_confusing function would run 2/3 of the characters through mb_encode_numericentity, but it forgot to do anything with the other 1/3. This fix makes it so the other 1/3 are passed through utf8tohtml properly.

This may fix some erroneous "You look like a bot" messages.
