### PR TITLE
Post Truncation fixes

### DIFF
--- a/inc/display.php
+++ b/inc/display.php
@@ -155,6 +155,11 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 		$max_lines = $config['body_truncate'];
 	if ($max_chars === false)
 		$max_chars = $config['body_truncate_char'];
+	
+	// We don't want to risk truncating in the middle of an HTML comment.
+	// It's easiest just to remove them all first.
+	$body = preg_replace('/<!--.*?-->/s', '', $body);
+	
 	$original_body = $body;
 	
 	$lines = substr_count($body, '<br/>');

--- a/inc/display.php
+++ b/inc/display.php
@@ -170,7 +170,7 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 			$body = $m[0];
 	}
 	
-	$body = substr($body, 0, $max_chars);
+	$body = mb_substr($body, 0, $max_chars);
 	
 	if ($body != $original_body) {
 		// Remove any corrupt tags at the end

--- a/inc/display.php
+++ b/inc/display.php
@@ -190,9 +190,12 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 			// remove broken HTML entity at the end (if existent)
 			$body = preg_replace('/&[^;]+$/', '', $body);
 			
+			$tags_no_close_needed = array("colgroup", "dd", "dt", "li", "optgroup", "option", "p", "tbody", "td", "tfoot", "th", "thead", "tr", "br", "img");
+			
 			// Close any open tags
 			foreach ($tags as &$tag) {
-				$body .= "</{$tag}>";
+				if (!in_array($tag, $tags_no_close_needed))
+					$body .= "</{$tag}>";
 			}
 		} else {
 			// remove broken HTML entity at the end (if existent)


### PR DESCRIPTION
These commits fix a few issues with the truncation of long posts in the index pages or mod interface.

[Not all tags require closing tags in HTML5](http://webdesign.about.com/od/htmltags/qt/optional-html-end-tags-when-to-include-them.htm), so if a raw HTML post is made with unclosed `<br>` or `<p>` tags, the truncated post has them all closed at the end, which can cause issues. Some browsers interpret a `</br>` tag as another line break, etc. The first commit fixes this with a list of tags it shouldn't try to close. (That list might not be complete.)

Next, if a raw HTML post contains an HTML comment ( <!-- comment --> ), then the post could be truncated partway through the comment, causing the rest of the page to be commented out. The second commit fixes this by just removing all HTML comments from the post before truncating it. The comments are still there when the thread is directly viewed. (Alternatively, it could be fixed like broken HTML entities are, leaving in any comments, but I didn't figure it was worth it. And I figured that characters in comments shouldn't count toward the max_chars limit.)

The third commit makes it so post truncation is done by the actual character count rather than byte count. Besides being more accurate and preventing cutting apart multi-byte character sequences, this fixes a bug where if a long post with many multi-byte characters is reported, the Dismiss buttons (and more) may be cut off from the report.
