### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/inc/display.php
+++ b/inc/display.php
@@ -216,7 +216,7 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 function secure_link_confirm($text, $title, $confirm_message, $href) {
 	global $config;
 
-	return '<a onclick="if (confirm(\'' . htmlentities(addslashes($confirm_message)) . '\')) document.location=\'?/' . htmlentities(addslashes($href . '/' . make_secure_link_token($href))) . '\';return false;" title="' . htmlentities($title) . '" href="?/' . $href . '">' . $text . '</a>';
+	return '<a onclick="if (event.which==2) return true;if (confirm(\'' . htmlentities(addslashes($confirm_message)) . '\')) document.location=\'?/' . htmlentities(addslashes($href . '/' . make_secure_link_token($href))) . '\';return false;" title="' . htmlentities($title) . '" href="?/' . $href . '">' . $text . '</a>';
 }
 function secure_link($href) {
 	return $href . '/' . make_secure_link_token($href);

--- a/inc/display.php
+++ b/inc/display.php
@@ -350,8 +350,8 @@ class Thread {
 			// Fix internal links
 			// Very complicated regex
 			$this->body = preg_replace(
-				'/<a(([a-zA-Z]+="[^"]+")|[a-zA-Z]+=[a-zA-Z]+|\s)*href="' . preg_quote($config['root'], '/') . '(' . sprintf(preg_quote($config['board_path'], '/'), '\w+') . ')/',
-				'<a href="?/$3',
+				'/<a((([a-zA-Z]+="[^"]+")|[a-zA-Z]+=[a-zA-Z]+|\s)*)href="' . preg_quote($config['root'], '/') . '(' . sprintf(preg_quote($config['board_path'], '/'), '\w+') . ')/',
+				'<a $1href="?/$4',
 				$this->body
 			);
 	}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -527,7 +527,7 @@ function checkFlood($post) {
 	
 	$query = prepare(sprintf("SELECT * FROM `posts_%s` WHERE (`ip` = :ip AND `time` >= :floodtime) OR (`ip` = :ip AND `body` != '' AND `body` = :body AND `time` >= :floodsameiptime) OR (`body` != ''  AND `body` = :body AND `time` >= :floodsametime) LIMIT 1", $board['uri']));
 	$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
-	$query->bindValue(':body', $post['body'], PDO::PARAM_INT);
+	$query->bindValue(':body', $post['body']);
 	$query->bindValue(':floodtime', time()-$config['flood_time'], PDO::PARAM_INT);
 	$query->bindValue(':floodsameiptime', time()-$config['flood_time_ip'], PDO::PARAM_INT);
 	$query->bindValue(':floodsametime', time()-$config['flood_time_same'], PDO::PARAM_INT);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -697,7 +697,7 @@ function threadExists($id) {
 
 function post(array $post) {
 	global $pdo, $board;
-	$query = prepare(sprintf("INSERT INTO `posts_%s` VALUES ( NULL, :thread, :subject, :email, :name, :trip, :capcode, :body, :body_nomarkup, :time, :time, :thumb, :thumbwidth, :thumbheight, :file, :width, :height, :filesize, :filename, :filehash, :password, :ip, :sticky, :locked, 0, :embed)", $board['uri']));
+	$query = prepare(sprintf("INSERT INTO `posts_%s` (`id`, `thread`, `subject`, `email`, `name`, `trip`, `capcode`, `body`, `body_nomarkup`, `time`, `bump`, `thumb`, `thumbwidth`, `thumbheight`, `file`, `filewidth`, `fileheight`, `filesize`, `filename`, `filehash`, `password`, `ip`, `sticky`, `locked`, `sage`, `embed`) VALUES ( NULL, :thread, :subject, :email, :name, :trip, :capcode, :body, :body_nomarkup, :time, :time, :thumb, :thumbwidth, :thumbheight, :file, :width, :height, :filesize, :filename, :filehash, :password, :ip, :sticky, :locked, 0, :embed)", $board['uri']));
 	
 	// Basic stuff
 	if (!empty($post['subject'])) {

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -64,6 +64,7 @@ function mod_confirm($request) {
 }
 
 function mod_logout() {
+	global $config;
 	destroyCookies();
 	
 	header('Location: ?/', true, $config['redirect_http']);

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1019,13 +1019,6 @@ function mod_deletefile($board, $post) {
 	// Record the action
 	modLog("Deleted file from post #{$post}");
 	
-	$query = prepare(sprintf('SELECT `thread` FROM `posts_%s` WHERE `id` = :id', $board));
-	$query->bindValue(':id', $post);
-	$query->execute() or error(db_error($query));
-	$thread = $query->fetchColumn();
-	
-	// Rebuild thread
-	buildThread($thread ? $thread : $post);
 	// Rebuild board
 	buildIndex();
 	

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -707,7 +707,7 @@ function mod_sticky($board, $unsticky, $post) {
 	$query->bindValue(':sticky', $unsticky ? 0 : 1);
 	$query->execute() or error(db_error($query));
 	if ($query->rowCount()) {
-		modLog(($unlock ? 'Unstickied' : 'Stickied') . " thread #{$post}");
+		modLog(($unsticky ? 'Unstickied' : 'Stickied') . " thread #{$post}");
 		buildThread($post);
 		buildIndex();
 	}
@@ -729,7 +729,7 @@ function mod_bumplock($board, $unbumplock, $post) {
 	$query->bindValue(':bumplock', $unbumplock ? 0 : 1);
 	$query->execute() or error(db_error($query));
 	if ($query->rowCount()) {
-		modLog(($unlock ? 'Unbumplocked' : 'Bumplocked') . " thread #{$post}");
+		modLog(($unbumplock ? 'Unbumplocked' : 'Bumplocked') . " thread #{$post}");
 		buildThread($post);
 		buildIndex();
 	}

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1406,6 +1406,8 @@ function mod_rebuild() {
 		error($config['error']['noaccess']);
 	
 	if (isset($_POST['rebuild'])) {
+		set_time_limit($config['mod']['rebuild_timelimit']);
+		
 		$log = array();
 		$boards = listBoards();
 		$rebuilt_scripts = array();

--- a/post.php
+++ b/post.php
@@ -407,34 +407,12 @@ if (isset($_POST['delete'])) {
 			
 			require_once 'inc/image.php';
 			
-			if ($config['thumb_method'] == 'imagick') {
-				// This is tricky, because Imagick won't let us find
-				// an image's dimensions without loading it all into
-				// memory first, unlike GD which provides the
-				// getimagesize() to do exactly that. This section
-				// is why GD is required, even when using Imagick
-				// instead. There doesn't seem to be an alternative.
-				// Necessary for security, as Imagick even ignores
-				// PHP's memory limit.
-				
-				// first try GD's getimagesize()
-				if ($size = @getimagesize($upload)) {
-					if ($size[0] > $config['max_width'] || $size[1] > $config['max_height']) {
-
-						error($config['error']['maxsize']);
-					}
-				} else {
-					// GD failed
-					// TODO?
-				}
-			} else {
-				// find dimensions of an image using GD
-				if (!$size = @getimagesize($upload)) {
-					error($config['error']['invalidimg']);
-				}
-				if ($size[0] > $config['max_width'] || $size[1] > $config['max_height']) {
-					error($config['error']['maxsize']);
-				}
+			// find dimensions of an image using GD
+			if (!$size = @getimagesize($upload)) {
+				error($config['error']['invalidimg']);
+			}
+			if ($size[0] > $config['max_width'] || $size[1] > $config['max_height']) {
+				error($config['error']['maxsize']);
 			}
 			
 			// create image object

--- a/templates/post_reply.html
+++ b/templates/post_reply.html
@@ -63,7 +63,7 @@
 					, {{ post.ratio }}
 				{% endif %}
 			{% endif %}
-			{% if config.show_filename %}
+			{% if config.show_filename and post.filename %}
 				, 
 				{% if post.filename|length > config.max_filename_display %}
 					<span title="{{ post.filename }}">{{ post.filename|truncate(config.max_filename_display) }}</span>

--- a/templates/post_thread.html
+++ b/templates/post_thread.html
@@ -20,7 +20,7 @@
 				, {{ post.ratio }}
 			{% endif %}
 		{% endif %}
-		{% if config.show_filename %}
+		{% if config.show_filename and post.filename %}
 			, 
 			{% if post.filename|length > config.max_filename_display %}
 				<span title="{{ post.filename }}">{{ post.filename|truncate(config.max_filename_display) }}</span>


### PR DESCRIPTION
1. Removes redundant call to buildThread() in mod_deletefile().
2. Firefox doesn't process call the onclick parameter of links when a link is middle-clicked, but Chrome does, which means Chrome users can't middle-click a moderator action to open it in a new tab. This commit fixes it by not doing anything in the onclick function if the link was middle-clicked.
3. mod_logout was missing a global and didn't use the redirect_http config setting.
4. mod_sticky and mod_bumplock both referred to the wrong variable while logging.
5. Don't show an empty filename if a post is missing its filename (such as if a post event removed it).
6. Two code paths in post.php's image processing were redundant. (Maybe the comment explaining why Imagick wasn't used was worthwhile.)
7. rebuild_timelimit config setting wasn't used after the mod interface rewrite.
8. mod_deletebyip was improved so it never rebuilds the same thread more than once.
9. The post() function's INSERT statement now specifies the columns it inserts into, so that way it won't explode if the table schema is changed.
10. The regex for fixing mod links in threads differed from the regex for fixing mods links in posts needlessly and was inferior.
11. A PDO parameter in a query in checkFlood() had the wrong type.
