### PR TITLE
Add image_reject_repost_in_thread option

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -445,8 +445,10 @@
 	// Maximum image dimensions
 	$config['max_width'] = 10000;
 	$config['max_height'] = $config['max_width']; // 1:1
-	// Reject dupliate image uploads
+	// Reject duplicate image uploads
 	$config['image_reject_repost'] = true;
+	// Reject duplicate image uploads within the same thread. Doesn't change anything if image_reject_repost is true.
+	$config['image_reject_repost_in_thread'] = false;
 	
 	// Display the aspect ratio in a post's file info
 	$config['show_ratio'] = false;
@@ -667,6 +669,7 @@
 	$config['error']['maxsize']		= _('The file was too big.');
 	$config['error']['invalidzip']		= _('Invalid archive!');
 	$config['error']['fileexists']		= _('That file <a href="%s">already exists</a>!');
+	$config['error']['fileexistsinthread']	= _('That file <a href="%s">already exists</a> in this thread!');
 	$config['error']['delete_too_soon']	= _('You\'ll have to wait another %s before deleting that.');
 	$config['error']['mime_exploit']	= _('MIME type detection XSS exploit (IE) detected; post discarded.');
 	$config['error']['invalid_embed']	= _('Couldn\'t make sense of the URL of the video you tried to embed.');

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1651,6 +1651,20 @@ function getPostByHash($hash) {
 	return false;
 }
 
+function getPostByHashInThread($hash, $thread) {
+	global $board;
+	$query = prepare(sprintf("SELECT `id`,`thread` FROM `posts_%s` WHERE `filehash` = :hash AND ( `thread` = :thread OR `id` = :thread )", $board['uri']));
+	$query->bindValue(':hash', $hash, PDO::PARAM_STR);
+	$query->bindValue(':thread', $thread, PDO::PARAM_INT);
+	$query->execute() or error(db_error($query));
+	
+	if ($post = $query->fetch()) {
+		return $post;
+	}
+	
+	return false;
+}
+
 function undoImage(array $post) {
 	if (!$post['has_file'])
 		return;

--- a/post.php
+++ b/post.php
@@ -500,17 +500,34 @@ if (isset($_POST['delete'])) {
 		}
 	}
 	
-	if ($post['has_file'] && $config['image_reject_repost'] && $p = getPostByHash($post['filehash'])) {
-		undoImage($post);
-		error(sprintf($config['error']['fileexists'], 
-			$post['mod'] ? $config['root'] . $config['file_mod'] . '?/' : $config['root'] .
-			$board['dir'] . $config['dir']['res'] .
-				($p['thread'] ?
-					$p['thread'] . '.html#' . $p['id']
-				:
-					$p['id'] . '.html'
-				)
-		));
+	if ($post['has_file']) {
+		if ($config['image_reject_repost']) {
+			if ($p = getPostByHash($post['filehash'])) {
+				undoImage($post);
+				error(sprintf($config['error']['fileexists'], 
+					$post['mod'] ? $config['root'] . $config['file_mod'] . '?/' : $config['root'] .
+					$board['dir'] . $config['dir']['res'] .
+						($p['thread'] ?
+							$p['thread'] . '.html#' . $p['id']
+						:
+							$p['id'] . '.html'
+						)
+				));
+			}
+		} else if (!$post['op'] && $config['image_reject_repost_in_thread']) {
+			if ($p = getPostByHashInThread($post['filehash'], $post['thread'])) {
+				undoImage($post);
+				error(sprintf($config['error']['fileexistsinthread'], 
+					$post['mod'] ? $config['root'] . $config['file_mod'] . '?/' : $config['root'] .
+					$board['dir'] . $config['dir']['res'] .
+						($p['thread'] ?
+							$p['thread'] . '.html#' . $p['id']
+						:
+							$p['id'] . '.html'
+						)
+				));
+			}
+		}
 	}
 	
 	if (!hasPermission($config['mod']['postunoriginal'], $board['uri']) && $config['robot_enable'] && checkRobot($post['body_nomarkup'])) {


### PR DESCRIPTION
Adds a image_reject_repost_in_thread config setting (defaulting to false) just like image_reject_repost, but instead of preventing reposting an image that's already on the board, it just prevents reposting an image that's already inside the same thread.

(If both image_reject_repost and image_reject_repost_in_thread are true, then there's no extra effect and it's as if only image_reject_repost is on.)

The feature is intended for boards with possibly overlapping picture dump threads, etc.
