### PR TITLE
Add multi-column key to optimize rebuilding index pages

### DIFF
--- a/templates/posts.sql
+++ b/templates/posts.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS `posts_{{ board }}` (
   `embed` text,
   UNIQUE KEY `id` (`id`),
   KEY `thread` (`thread`),
+  KEY `thread_id` (`thread`, `id`),
   KEY `time` (`time`),
   FULLTEXT KEY `body` (`body`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;

--- a/templates/posts.sql
+++ b/templates/posts.sql
@@ -26,7 +26,6 @@ CREATE TABLE IF NOT EXISTS `posts_{{ board }}` (
   `sage` int(1) NOT NULL,
   `embed` text,
   UNIQUE KEY `id` (`id`),
-  KEY `thread` (`thread`),
   KEY `thread_id` (`thread`, `id`),
   KEY `time` (`time`),
   FULLTEXT KEY `body` (`body`)


### PR DESCRIPTION
The commit adds a key on (`thread`, `id`) to posts_%s to optimize this query, which is called a lot of times on every post to recreate the index pages:

```
$posts = prepare(sprintf("SELECT * FROM `posts_%s` WHERE `thread` = :id ORDER BY `id` DESC LIMIT :limit", $board['uri']));
```

This gave me a noticeable speed-up. (Using the cache also helps this performance point a lot, though I haven't gotten around to setting that up, and it seems to be broken/disabled in the current git commit.)

This SQL query will need to be run on each of the posts_\* tables, so it probably should go somewhere into install.php:

```
create index `thread_id` on posts_%s (`thread`, `id`);
```
