### PR TITLE
Add field_disable_subject and field_disable_reply_subject config options

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -348,6 +348,10 @@
 	$config['field_disable_name'] = false;
 	// When true, no email will be able to be set.
 	$config['field_disable_email'] = false;
+	// When true, no subject will be able to be set.
+	$config['field_disable_subject'] = false;
+	// When true, no subject will be able to be set in replies.
+	$config['field_disable_reply_subject'] = false;
 	// When true, a blank password will be used for files (not usable for deletion).
 	$config['field_disable_password'] = false;
 	

--- a/post.php
+++ b/post.php
@@ -139,7 +139,7 @@ if (isset($_POST['delete'])) {
 	header('Location: ' . $root . $board['dir'] . $config['file_index'], true, $config['redirect_http']);
 } elseif (isset($_POST['post'])) {
 	
-	if (!isset($_POST['subject'], $_POST['body'], $_POST['board']))
+	if (!isset($_POST['body'], $_POST['board']))
 		error($config['error']['bot']);
 	
 	if (!isset($_POST['name']))
@@ -147,6 +147,9 @@ if (isset($_POST['delete'])) {
 	
 	if (!isset($_POST['email']))
 		$_POST['email'] = '';
+	
+	if (!isset($_POST['subject']))
+		$_POST['subject'] = '';
 	
 	if (!isset($_POST['password']))
 		$_POST['password'] = '';
@@ -271,6 +274,9 @@ if (isset($_POST['delete'])) {
 	
 		if ($config['field_disable_password'])
 			$_POST['password'] = '';
+	
+		if ($config['field_disable_subject'] || (!$post['op'] && $config['field_disable_reply_subject']))
+			$_POST['subject'] = '';
 	}
 	
 	// Check for a file

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -27,12 +27,18 @@
 			</td>
 		</tr>{% endif %}
 		<tr>
-			<th>
+			{% if not (config.field_disable_subject or (id and config.field_disable_reply_subject)) or (mod and post.mod|hasPermission(config.mod.bypass_field_disable, board.uri)) %}<th>
 				{% trans %}Subject{% endtrans %}
 				{{ antibot.html() }}
 			</th>
 			<td>
 				<input style="float:left;" type="text" name="subject" size="25" maxlength="100" autocomplete="off">
+			{% else %}<th>
+				{% trans %}Submit{% endtrans %}
+				{{ antibot.html() }}
+			</th>
+			<td>
+			{% endif %}
 				<input accesskey="s" style="margin-left:2px;" type="submit" name="post" value="{% if id %}{{ config.button_reply }}{% else %}{{ config.button_newtopic }}{% endif %}" />{% if config.spoiler_images %} <input id="spoiler" name="spoiler" type="checkbox"> <label for="spoiler">{% trans %}Spoiler Image{% endtrans %}</label>{% endif %}
 			</td>
 		</tr>


### PR DESCRIPTION
Adds field_disable_subject config option to go with field_disable_name and field_disable_email. Also adds a field_disable_reply_subject setting which only allows OPs to have a subject. (Has no additional effect if field_disable_subject is already on.)
