### PR TITLE
Add Redis caching support

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -91,6 +91,7 @@
  	
  	$config['cache']['enabled'] = false;
  	// $config['cache']['enabled'] = 'memcached';
+ 	// $config['cache']['enabled'] = 'redis';
  	// $config['cache']['enabled'] = 'apc';
  	// $config['cache']['enabled'] = 'xcache';
  	
@@ -104,6 +105,11 @@
 	$config['cache']['memcached'] = array(
 		array('localhost', 11211)
 	);
+
+	// Redis server to use. Location, port, password, database id.
+	// Note that Tinyboard may clear the database at times, so you may want to pick a
+	// database id just for Tinyboard to use.
+	$config['cache']['redis'] = array('localhost', 6379, '', 1);
 	
 /*
  * ====================


### PR DESCRIPTION
Adds support for using Redis as the caching layer. (Redis is similar to memcache with optional persistence and some extra data structure support. Not that the extra stuff is really used here, but it's convenient if Redis is already in use on the server.)

Requires the phpredis extension if redis is chosen as the cache:
https://github.com/nicolasff/phpredis
