### PR TITLE
Fix truncation issues once and for all 

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1494,7 +1494,7 @@ function markup(&$body, $track_cites = false) {
 }
 
 function utf8tohtml($utf8) {
-	return mb_encode_numericentity(htmlspecialchars($utf8, ENT_NOQUOTES, 'UTF-8'), array(0x80, 0xffff, 0, 0xffff), 'UTF-8');
+	return htmlspecialchars($utf8, ENT_NOQUOTES, 'UTF-8');
 }
 
 function buildThread($id, $return=false, $mod=false) {


### PR DESCRIPTION
I've been working on this commit for a while, and my original work all had to do with keeping HTML entities intact.

I scrapped all of that in favor of this simple change. This permanently fixes the truncation issues that plague tinyboard, but is still secure (i.e., it still encodes <, >, &, etc).

The truncation issue is very simple, currently, when Tinyboard receives a Unicode filename, like `スクリーンショット<b>.png`, it converts it into HTML entities...

`&#12473;&#12463;&#12522;&#12540;&#12531;&#12471;&#12519;&#12483;&#12488;&lt;b&gt;.png`

And then _erroneously_ uses these to truncate at the set number, which not only slices in the wrong place, but cuts HTML entities in half, resulting in `&#12473;&#12463;&#12522;&#1254` or `スクリӦ…`.

This affects all fields with truncation, including the body text, which can also be truncated in the middle of an HTML entity.

I tried to fix this a few different ways but eventually just decided it's 2013 and server admins should set their `Content-Type` to `utf-8` already. I hope you will accept this pull request.

![2013-03-17-070939_906x359_scrot](https://f.cloud.github.com/assets/838783/267987/37892a18-8ef3-11e2-9c94-65c20115eaa7.png)
This image shows the fix with this patch.
