### PR TITLE
Per board configuration names were not working

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -858,8 +858,8 @@
 	$config['mod']['shadow_mesage'] = 'Moved to %s.';
 	// Capcode to use when posting the above message.
 	$config['mod']['shadow_capcode'] = 'Mod';
-	// Name to use when posting the above message.
-	$config['mod']['shadow_name'] = $config['anonymous'];
+	// Name to use when posting the above message. If false, the default board name will be used. If something else, that will be used.
+	$config['mod']['shadow_name'] = false;
 	
 	// Wait indefinitely when rebuilding everything
 	$config['mod']['rebuild_timelimit'] = 0;

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -912,7 +912,7 @@ function mod_move($originBoard, $postID) {
 				'mod' => true,
 				'subject' => '',
 				'email' => '',
-				'name' => $config['mod']['shadow_name'],
+				'name' => (!$config['mod']['shadow_name'] ? $config['anonymous'] : $config['mod']['shadow_name']),
 				'capcode' => $config['mod']['shadow_capcode'],
 				'trip' => '',
 				'password' => '',


### PR DESCRIPTION
When I moved a thread, the default name "Anonymous" was used even though I set "Anonymage" in config.php for the board.

![2013-03-20-075740_916x543_scrot](https://f.cloud.github.com/assets/838783/280404/fb5af214-9155-11e2-8be0-e3bbfeabc4b1.png)

This is because the `shadow_name` configuration option inherits from the default "Anonymous" in config.php.

This commit fixes that.

![2013-03-20-075928_910x286_scrot](https://f.cloud.github.com/assets/838783/280394/96d01d88-9155-11e2-821b-47ef0f60c3fa.png)
