### PR TITLE
Output times in UTC

### DIFF
--- a/inc/lib/Twig/Extensions/Extension/Tinyboard.php
+++ b/inc/lib/Twig/Extensions/Extension/Tinyboard.php
@@ -57,8 +57,7 @@ class Twig_Extensions_Extension_Tinyboard extends Twig_Extension
 }
 
 function twig_timezone_function() {
-	// there's probably a much easier way of doing this
-	return sprintf("%s%02d", ($hr = (int)floor(($tz = date('Z')) / 3600)) > 0 ? '+' : '-', abs($hr)) . ':' . sprintf("%02d", (($tz / 3600) - $hr) * 60);
+	return 'Z';
 }
 
 function twig_split_filter($str, $delim) {
@@ -75,7 +74,7 @@ function twig_remove_whitespace_filter($data) {
 }
 
 function twig_date_filter($date, $format) {
-	return strftime($format, $date);
+	return gmstrftime($format, $date);
 }
 
 function twig_hasPermission_filter($mod, $permission, $board = null) {


### PR DESCRIPTION
Let the client localize the times with js/local-time.js themselves. No one cares what the server timezone is.

On March 10, when daylight savings began, I had an issue where the utc-offset rendered in templates on all posts changed, but the time didn't. The calculated utc-offset was for the current time, and didn't reflect the status of daylight-savings at the time of the timestamp. This meant that after March 10, all posts made before March 10 suddenly appeared an hour older. This commit fixes the issue by just rendering all times as UTC. I couldn't figure out a good solution that keeps the server's local timezone.

(I probably wouldn't have noticed this normally, but this caused issues with a thread watcher feature on mlpchan. The thread watcher script would remember the timestamp of the last post in a watched thread when you viewed it, and it would regularly query the server in an AJAX call for the timestamps of the last replies to all watched threads. The AJAX call still gave the correct timestamps, but the threads with pre-March 10 replies showed up as an hour older, so the watcher script constantly thought that there had been a more recent post and would alert the user eternally even after they visited the thread.)
