### PR TITLE
Fix display issues with RTL control characters in post names, subjects, ...

### DIFF
--- a/inc/display.php
+++ b/inc/display.php
@@ -213,6 +213,39 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 	return $body;
 }
 
+function bidi_cleanup($str){
+	# Closes all embedded RTL and LTR unicode formatting blocks in a string so that
+	# it can be used inside another without controlling its direction.
+	# More info: http://www.iamcal.com/understanding-bidirectional-text/
+	#
+	# LRE - U+202A - 0xE2 0x80 0xAA
+	# RLE - U+202B - 0xE2 0x80 0xAB
+	# LRO - U+202D - 0xE2 0x80 0xAD
+	# RLO - U+202E - 0xE2 0x80 0xAE
+	#
+	# PDF - U+202C - 0xE2 0x80 0xAC
+	#
+	$explicits	= '\xE2\x80\xAA|\xE2\x80\xAB|\xE2\x80\xAD|\xE2\x80\xAE';
+	$pdf		= '\xE2\x80\xAC';
+
+	$stack = 0;
+	$str = preg_replace_callback("!(?<explicits>$explicits)|(?<pdf>$pdf)!", function($match) use (&$stack) {
+		if (isset($match['explicits']) && $match['explicits']) {
+			$stack++;
+		} else {
+			if ($stack)
+				$stack--;
+			else
+				return '';
+		}
+		return $match[0];
+	}, $str);
+	for ($i=0; $i<$stack; $i++){
+		$str .= "\xE2\x80\xAC";
+	}
+	return $str;
+}
+
 function secure_link_confirm($text, $title, $confirm_message, $href) {
 	global $config;
 

--- a/inc/lib/Twig/Extensions/Extension/Tinyboard.php
+++ b/inc/lib/Twig/Extensions/Extension/Tinyboard.php
@@ -25,6 +25,7 @@ class Twig_Extensions_Extension_Tinyboard extends Twig_Extension
 			'until' => new Twig_Filter_Function('until'),
 			'split' => new Twig_Filter_Function('twig_split_filter'),
 			'push' => new Twig_Filter_Function('twig_push_filter'),
+			'bidi_cleanup' => new Twig_Filter_Function('bidi_cleanup'),
 			'addslashes' => new Twig_Filter_Function('addslashes')
 		);
 	}

--- a/templates/post_reply.html
+++ b/templates/post_reply.html
@@ -7,14 +7,14 @@
 	<label for="delete_{{ post.id }}">
 		{% if post.subject|length > 0 %}
 			{# show subject #}
-			<span class="subject">{{ post.subject }}</span> 
+			<span class="subject">{{ post.subject|bidi_cleanup }}</span> 
 		{% endif %}
 		{% if post.email|length > 0 %}
 			{# start email #}
 			<a class="email" href="mailto:{{ post.email }}">
 		{% endif %}
 		{% set capcode = post.capcode|capcode %}
-		<span {% if capcode.name %}style="{{ capcode.name }}" {% endif %}class="name">{{ post.name }}</span>
+		<span {% if capcode.name %}style="{{ capcode.name }}" {% endif %}class="name">{{ post.name|bidi_cleanup }}</span>
 		{% if post.trip|length > 0 %}
 			<span {% if capcode.trip %}style="{{ capcode.trip }}" {% endif %}class="trip">{{ post.trip }}</span>
 		{% endif %}
@@ -66,9 +66,9 @@
 			{% if config.show_filename and post.filename %}
 				, 
 				{% if post.filename|length > config.max_filename_display %}
-					<span title="{{ post.filename }}">{{ post.filename|truncate(config.max_filename_display) }}</span>
+					<span class="postfilename" title="{{ post.filename|bidi_cleanup }}">{{ post.filename|truncate(config.max_filename_display)|bidi_cleanup }}</span>
 				{% else %}
-					{{ post.filename }}
+					<span class="postfilename">{{ post.filename|bidi_cleanup }}</span>
 				{% endif %}
 			{% endif %}
 		)

--- a/templates/post_thread.html
+++ b/templates/post_thread.html
@@ -22,11 +22,11 @@
 		{% endif %}
 		{% if config.show_filename and post.filename %}
 			, 
-			{% if post.filename|length > config.max_filename_display %}
-				<span title="{{ post.filename }}">{{ post.filename|truncate(config.max_filename_display) }}</span>
-			{% else %}
-				{{ post.filename }}
-			{% endif %}
+			{% if post.filename|length > config.max_filename_display %}
+				<span class="postfilename" title="{{ post.filename|bidi_cleanup }}">{{ post.filename|truncate(config.max_filename_display)|bidi_cleanup }}</span>
+			{% else %}
+				<span class="postfilename">{{ post.filename|bidi_cleanup }}</span>
+			{% endif %}
 		{% endif %}
 	)
 	</span></p>
@@ -50,14 +50,14 @@
 	<label for="delete_{{ post.id }}">
 		{% if post.subject|length > 0 %}
 			{# show subject #}
-			<span class="subject">{{ post.subject }}</span> 
+			<span class="subject">{{ post.subject|bidi_cleanup }}</span> 
 		{% endif %}
 		{% if post.email|length > 0 %}
 			{# start email #}
 			<a class="email" href="mailto:{{ post.email }}">
 		{% endif %}
 		{% set capcode = post.capcode|capcode %}
-		<span {% if capcode.name %}style="{{ capcode.name }}" {% endif %}class="name">{{ post.name }}</span>
+		<span {% if capcode.name %}style="{{ capcode.name }}" {% endif %}class="name">{{ post.name|bidi_cleanup }}</span>
 		{% if post.trip|length > 0 %}
 			<span {% if capcode.trip %}style="{{ capcode.trip }}" {% endif %}class="trip">{{ post.trip }}</span>
 		{% endif %}


### PR DESCRIPTION
Fix display issues with RTL control characters in post names, subjects, and filenames.

A user who uses Right-to-Left Embedding or Override characters in their name, subject, or filenames can mess up the visual appearance of other fields on the same line. (This isn't an issue for the post body for example, because nothing else is displayed on the same line as it.)

This commit fixes it by introducing the bidi_cleanup function (called from within the templates), which pairs all LRE, RLE, LRO, RLO characters with Pop-Directional-Formatting characters (and removes any improper PDF characters), based on code from http://www.iamcal.com/understanding-bidirectional-text/
