### PR TITLE
Miscellaneous fixes

### DIFF
--- a/inc/display.php
+++ b/inc/display.php
@@ -118,7 +118,7 @@ function pm_snippet($body, $len=null) {
 	// calculate strlen() so we can add "..." after if needed
 	$strlen = mb_strlen($body);
 	
-	$body = substr($body, 0, $len);
+	$body = mb_substr($body, 0, $len);
 	
 	// Re-escape the characters.
 	return '<em>' . utf8tohtml($body) . ($strlen > $len ? '&hellip;' : '') . '</em>';

--- a/inc/display.php
+++ b/inc/display.php
@@ -204,7 +204,7 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 			}
 		} else {
 			// remove broken HTML entity at the end (if existent)
-			$body = preg_replace('/&[^;]+$/', '', $body);
+			$body = preg_replace('/&[^;]*$/', '', $body);
 		}
 		
 		$body .= '<span class="toolong">Post too long. Click <a href="' . $url . '">here</a> to view the full text.</span>';

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1362,8 +1362,8 @@ function unicodify($body) {
 	// En and em- dashes are rendered exactly the same in
 	// most monospace fonts (they look the same in code
 	// editors).
-	$body = str_replace('--', '&ndash;', $body); // en dash
 	$body = str_replace('---', '&mdash;', $body); // em dash
+	$body = str_replace('--', '&ndash;', $body); // en dash
 	
 	return $body;
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -722,13 +722,13 @@ function post(array $post) {
 	$query->bindValue(':password', $post['password']);		
 	$query->bindValue(':ip', isset($post['ip']) ? $post['ip'] : $_SERVER['REMOTE_ADDR']);
 	
-	if ($post['op'] && $post['mod'] && $post['sticky']) {
+	if ($post['op'] && $post['mod'] && isset($post['sticky']) && $post['sticky']) {
 		$query->bindValue(':sticky', 1, PDO::PARAM_INT);
 	} else {
 		$query->bindValue(':sticky', 0, PDO::PARAM_INT);
 	}
 	
-	if ($post['op'] && $post['mod'] && $post['locked']) {
+	if ($post['op'] && $post['mod'] && isset($post['locked']) && $post['locked']) {
 		$query->bindValue(':locked', 1, PDO::PARAM_INT);
 	} else {
 		$query->bindValue(':locked', 0, PDO::PARAM_INT);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -328,11 +328,19 @@ function setupBoard($array) {
 }
 
 function openBoard($uri) {
+	$board = getBoardInfo($uri);
+	if ($board) {
+		setupBoard($board);
+		return true;
+	}
+	return false;
+}
+
+function getBoardInfo($uri) {
 	global $config;
 
 	if ($config['cache']['enabled'] && ($board = cache::get('board_' . $uri))) {
-		setupBoard($board);
-		return true;
+		return $board;
 	}
 	
 	$query = prepare("SELECT * FROM `boards` WHERE `uri` = :uri LIMIT 1");
@@ -342,27 +350,16 @@ function openBoard($uri) {
 	if ($board = $query->fetch()) {
 		if ($config['cache']['enabled'])
 			cache::set('board_' . $uri, $board);
-		setupBoard($board);
-		return true;
+		return $board;
 	}
 
 	return false;
 }
 
 function boardTitle($uri) {
-	global $config;
-	if ($config['cache']['enabled'] && ($board = cache::get('board_' . $uri))) {
+	$board = getBoardInfo($uri);
+	if ($board)
 		return $board['title'];
-	}
-	
-	$query = prepare("SELECT `title` FROM `boards` WHERE `uri` = :uri LIMIT 1");
-	$query->bindValue(':uri', $uri);
-	$query->execute() or error(db_error($query));
-	
-	if ($title = $query->fetch()) {
-		return $title['title'];
-	}
-
 	return false;
 }
 

--- a/inc/mod/auth.php
+++ b/inc/mod/auth.php
@@ -125,7 +125,7 @@ if (isset($_COOKIE[$config['cookies']['mod']])) {
 function create_pm_header() {
 	global $mod, $config;
 	
-	if ($config['cache']['enabled'] && ($header = cache::get('pm_unread_' . $mod['id'])) !== false) {
+	if ($config['cache']['enabled'] && ($header = cache::get('pm_unread_' . $mod['id'])) != false) {
 		if ($header === true)
 			return false;
 	

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1832,6 +1832,7 @@ function mod_theme_configure($theme_name) {
 			'result' => $result,
 			'message' => $message,
 		));
+		return;
 	}
 
 	$settings = themeSettings($theme_name);

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -89,7 +89,7 @@ function mod_dashboard() {
 		}
 	}
 	
-	if (!$config['cache']['enabled'] || ($args['unread_pms'] = cache::get('pm_unreadcount_' . $mod['id'])) === false) {
+	if (!$config['cache']['enabled'] || ($args['unread_pms'] = cache::get('pm_unreadcount_' . $mod['id'])) == false) {
 		$query = prepare('SELECT COUNT(*) FROM `pms` WHERE `to` = :id AND `unread` = 1');
 		$query->bindValue(':id', $mod['id']);
 		$query->execute() or error(db_error($query));

--- a/js/post-hover.js
+++ b/js/post-hover.js
@@ -20,6 +20,8 @@ onready(function(){
 		
 		if(id = $link.text().match(/^>>(\d+)$/)) {
 			id = id[1];
+		} else {
+			return;
 		}
 		
 		var $post = false;

--- a/mod.php
+++ b/mod.php
@@ -105,7 +105,7 @@ $new_pages = array();
 foreach ($pages as $key => $callback) {
 	if (preg_match('/^secure /', $callback))
 		$key .= '(/(?P<token>[a-f0-9]{8}))?';
-	$new_pages[@$key[0] == '!' ? $key : "!^$key$!"] = $callback;
+	$new_pages[@$key[0] == '!' ? $key : '!^' . $key . '(?:&[^&=]+=[^&]*)*$!'] = $callback;
 }
 $pages = $new_pages;
 

--- a/templates/main.js
+++ b/templates/main.js
@@ -105,7 +105,7 @@ function generatePassword() {
 
 function dopost(form) {
 	if (form.elements['name']) {
-		localStorage.name = form.elements['name'].value.replace(/ ##.+$/, '');
+		localStorage.name = form.elements['name'].value.replace(/( |^)## .+$/, '');
 	}
 	if (form.elements['email'] && form.elements['email'].value != 'sage') {
 		localStorage.email = form.elements['email'].value;

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,7 +7,12 @@
 	<title>{{ title }}</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
 	{% if config.default_stylesheet.1 != '' %}<link rel="stylesheet" type="text/css" id="stylesheet" href="{{ config.uri_stylesheets }}{{ config.default_stylesheet.1 }}">{% endif %}
-	{% if not nojavascript %}<script type="text/javascript" src="{{ config.url_javascript }}"></script>{% endif %}
+	{% if not nojavascript %}
+		<script type="text/javascript" src="{{ config.url_javascript }}"></script>
+		{% if not config.additional_javascript_compile %}
+		{% for javascript in config.additional_javascript %}<script type="text/javascript" src="{{ config.additional_javascript_url }}{{ javascript }}"></script>{% endfor %}
+		{% endif %}
+	{% endif %}
 </head>
 <body>
 	{% if pm %}<div class="top_notice">You have <a href="?/PM/{{ pm.id }}">an unread PM</a>{% if pm.waiting > 0 %}, plus {{ pm.waiting }} more waiting{% endif %}.</div><hr>{% endif %}


### PR DESCRIPTION
- Fixes issue where false-y values were treated as present when reading cached info about PMs. The redis cache backend returns null if a key isn't found rather than false, so this over-strictness was an issue. A false-y value shouldn't be returned by any of the backends if the key is present in this case.
- Make pm_snippet use mb_substr.
- Fixed openBoard and boardTitle functions to not trample each other's cache, and refactored their common functionality so they both call getBoardInfo.
- Fixed issue with page after a theme is installed.
- Fix broken entity removal in post truncation. The regex was incorrect and would not remove a single "&" character at the end.
- Make mod.php ignore extra URL parameters. jQuery appends some parameters like "&_=1371573728564" to a URL in AJAX requests set with cache:false, which used to break requests to pages under mod.php.

I think none of these changes are too controversial, so I've bundled them up into one pull request unlike the others.
