### PR TITLE
Adds image_hard_limit and reply_hard_limit options

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -311,6 +311,11 @@
 	// Reply limit (stops bumping thread when this is reached)
 	$config['reply_limit'] = 250;
 	
+	// Image hard limit (stops allowing new image replies when this is reached if not zero)
+	$config['image_hard_limit'] = 0;
+	// Reply hard limit (stops allowing new replies when this is reached if not zero)
+	$config['reply_hard_limit'] = 0;
+	
 	// Strip repeating characters when making hashes
 	$config['robot_enable'] = false;
 	$config['robot_strip_repeating'] = true;
@@ -659,6 +664,8 @@
 	$config['error']['noboard']		= _('Invalid board!');
 	$config['error']['nonexistant']		= _('Thread specified does not exist.');
 	$config['error']['locked']		= _('Thread locked. You may not reply at this time.');
+	$config['error']['reply_hard_limit']	= _('Thread has reached its maximum reply limit.');
+	$config['error']['image_hard_limit']	= _('Thread has reached its maximum image limit.');
 	$config['error']['nopost']		= _('You didn\'t make a post.');
 	$config['error']['flood']		= _('Flood detected; Post discarded.');
 	$config['error']['spam']		= _('Your request looks automated; Post discarded.');

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -986,12 +986,8 @@ function index($page, $mod=false) {
 			$replies = array_reverse($posts->fetchAll(PDO::FETCH_ASSOC));
 			
 			if (count($replies) == ($th['sticky'] ? $config['threads_preview_sticky'] : $config['threads_preview'])) {
-				$count = prepare(sprintf("SELECT COUNT(`id`) as `num` FROM `posts_%s` WHERE `thread` = :thread UNION ALL SELECT COUNT(`id`) FROM `posts_%s` WHERE `file` IS NOT NULL AND `thread` = :thread", $board['uri'], $board['uri']));
-				$count->bindValue(':thread', $th['id'], PDO::PARAM_INT);
-				$count->execute() or error(db_error($count));
-				$count = $count->fetchAll(PDO::FETCH_COLUMN);
-				
-				$omitted = array('post_count' => $count[0], 'image_count' => $count[1]);
+				$count = numPosts($th['id']);
+				$omitted = array('post_count' => $count['replies'], 'image_count' => $count['images']);
 			} else {
 				$omitted = false;
 			}
@@ -1134,14 +1130,19 @@ function checkRobot($body) {
 	return false;
 }
 
+// Returns an associative array with 'replies' and 'images' keys
 function numPosts($id) {
 	global $board;
-	$query = prepare(sprintf("SELECT COUNT(*) as `count` FROM `posts_%s` WHERE `thread` = :thread", $board['uri']));
+	$query = prepare(sprintf("SELECT COUNT(*) as `num` FROM `posts_%s` WHERE `thread` = :thread UNION ALL SELECT COUNT(*) FROM `posts_%s` WHERE `file` IS NOT NULL AND `thread` = :thread", $board['uri'], $board['uri']));
 	$query->bindValue(':thread', $id, PDO::PARAM_INT);
 	$query->execute() or error(db_error($query));
 	
-	$result = $query->fetch();
-	return $result['count'];
+	$num_posts = $query->fetch();
+	$num_posts = $num_posts['num'];
+	$num_images = $query->fetch();
+	$num_images = $num_images['num'];
+	
+	return array('replies' => $num_posts, 'images' => $num_images);
 }
 
 function muteTime() {

--- a/post.php
+++ b/post.php
@@ -302,13 +302,21 @@ if (isset($_POST['delete'])) {
 		}
 	}
 	
-	// Check if thread is locked
-	// but allow mods to post
-	if (!$post['op'] && !hasPermission($config['mod']['postinlocked'], $board['uri'])) {
-		if ($thread['locked'])
+	if (!$post['op']) {
+		// Check if thread is locked
+		// but allow mods to post
+		if ($thread['locked'] && !hasPermission($config['mod']['postinlocked'], $board['uri']))
 			error($config['error']['locked']);
+		
+		$numposts = numPosts($post['thread']);
+		
+		if ($config['reply_hard_limit'] != 0 && $config['reply_hard_limit'] <= $numposts['replies'])
+			error($config['error']['reply_hard_limit']);
+		
+		if ($post['has_file'] && $config['image_hard_limit'] != 0 && $config['image_hard_limit'] <= $numposts['images'])
+			error($config['error']['image_hard_limit']);
 	}
-	
+		
 	if ($post['has_file']) {
 		$size = $_FILES['file']['size'];
 		if ($size > $config['max_filesize'])
@@ -636,7 +644,7 @@ if (isset($_POST['delete'])) {
 	
 	buildThread($post['op'] ? $id : $post['thread']);
 	
-	if (!$post['op'] && strtolower($post['email']) != 'sage' && !$thread['sage'] && ($config['reply_limit'] == 0 || numPosts($post['thread']) < $config['reply_limit'])) {
+	if (!$post['op'] && strtolower($post['email']) != 'sage' && !$thread['sage'] && ($config['reply_limit'] == 0 || $numposts['replies']+1 < $config['reply_limit'])) {
 		bumpThread($post['thread']);
 	}
 	


### PR DESCRIPTION
Allows maximum reply and image limits to be set for threads. Also reworks the numPosts() function and uses it elsewhere too.

Threads that get very large (>10k posts) can cause issues, such as PHP running out of memory when attempting to build the thread. Very large threads that get posts constantly can cause big performance issues.

(Maybe $config['reply_limit'] should be renamed $config['bump_limit'] to more accurately reflect its purpose.)
