### PR TITLE
Remove all RTL and LTR control codes in bidi_cleanup.

### DIFF
--- a/inc/display.php
+++ b/inc/display.php
@@ -214,7 +214,7 @@ function truncate($body, $url, $max_lines = false, $max_chars = false) {
 }
 
 function bidi_cleanup($str){
-	# Closes all embedded RTL and LTR unicode formatting blocks in a string so that
+	# Removes all embedded RTL and LTR unicode formatting blocks in a string so that
 	# it can be used inside another without controlling its direction.
 	# More info: http://www.iamcal.com/understanding-bidirectional-text/
 	#
@@ -228,21 +228,7 @@ function bidi_cleanup($str){
 	$explicits	= '\xE2\x80\xAA|\xE2\x80\xAB|\xE2\x80\xAD|\xE2\x80\xAE';
 	$pdf		= '\xE2\x80\xAC';
 
-	$stack = 0;
-	$str = preg_replace_callback("!(?<explicits>$explicits)|(?<pdf>$pdf)!", function($match) use (&$stack) {
-		if (isset($match['explicits']) && $match['explicits']) {
-			$stack++;
-		} else {
-			if ($stack)
-				$stack--;
-			else
-				return '';
-		}
-		return $match[0];
-	}, $str);
-	for ($i=0; $i<$stack; $i++){
-		$str .= "\xE2\x80\xAC";
-	}
+	$str = preg_replace("!(?<explicits>$explicits)|(?<pdf>$pdf)!", '', $str);
 	return $str;
 }
 


### PR DESCRIPTION
If the name and subject fields both start with RLO characters, then the subject would be after the name with the old bidi_cleanup. This change makes the bidi_cleanup function just remove all right-to-left and left-to-right related unicode control characters. This should also fix issue #120 as an anonymous function is no longer used.
