### PR TITLE
Fix is_writable check for templates/cache

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -23,7 +23,7 @@ function load_twig() {
 	$loader->setPaths($config['dir']['template']);
 	$twig = new Twig_Environment($loader, array(
 		'autoescape' => false,
-		'cache' => is_writable('templates') && (!is_dir('templates/cache') || is_writable('templates/cache')) ?
+		'cache' => is_writable('templates') || (is_dir('templates/cache') && is_writable('templates/cache')) ?
 			"{$config['dir']['template']}/cache" : false,
 		'debug' => $config['debug']
 	));

--- a/install.php
+++ b/install.php
@@ -654,7 +654,7 @@ if ($step == 0) {
 		array(
 			'category' => 'File permissions',
 			'name' => getcwd() . '/templates/cache',
-			'result' => is_writable('templates') && (!is_dir('templates/cache') || is_writable('templates/cache')),
+			'result' => is_writable('templates') || (is_dir('templates/cache') && is_writable('templates/cache')),
 			'required' => true,
 			'message' => 'You must give Tinyboard permission to create (and write to) the <code>templates/cache</code> directory or performance will be drastically reduced.'
 		),


### PR DESCRIPTION
`templates/cache/` has been reported as not-writable when `templates/cache/` was writable but `templates/` wasn't.
