### PR TITLE
Add -quiet to convert_args

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -626,7 +626,7 @@
 
 	// Command-line options passed to ImageMagick when using `convert` for thumbnailing. Don't touch the
 	// placement of "%s" and "%d".
-	$config['convert_args'] = '-size %dx%d %s -thumbnail %dx%d -auto-orient +profile "*" %s';
+	$config['convert_args'] = '-quiet -size %dx%d %s -thumbnail %dx%d -auto-orient +profile "*" %s';
 
 	// Strip EXIF metadata from JPEG files.
 	$config['strip_exif'] = false;


### PR DESCRIPTION
With newer versions of libpng (mine is 1.6.12) it will throw some form of error when using programs like imagemagick, gimp, etc. with a png image with a certain (incorrect?) color profile, sRGB IEC61966-2.1 specifically.

There is bug reports all over the web about this (mainly regarding GIMP, because it will actually refuse to save the image with that color profile), but apparently this is intentional behavoir from libpng, not a bug.

Anyway, the exact error imagemagick's convert will give out when converting is `convert: iCCP: known incorrect sRGB profile `example.png' @ warning/png.c/MagickPNGWarningHandler/1832.`

This however is just a warning, it converts the image fine and returns a 0 exit status. The problem comes in with Tinyboard's way of handling imagemagick errors in inc/image.php apparently, any output is considered an error I think.  Point is it would convert the image just fine, except Tinyboard sees that extra output as an error and will just take you to the error page, say "Failed to resize image", and won't let you post.

Please pull this, or if you want re-configure the way it would detect errors, I tried but I'm not that great of a programmer.
